### PR TITLE
bugfix date before 1943

### DIFF
--- a/src/Service/BirthPlaceService.php
+++ b/src/Service/BirthPlaceService.php
@@ -84,6 +84,14 @@ class BirthPlaceService
      */
     public function searchBirthPlacesByDate(string $search, DateTime $date): array
     {
+        // seuil INSEE : 1er janvier 1943
+        $threshold = new DateTime('1943-01-01');
+
+        if ($date < $threshold) {
+            $date = $threshold;
+        }
+
+        // sinon, DOB >= 1943 → interroger la base historique avec dates
         /** @var InseeCommune1943Repository $commune1943Repository */
         $commune1943Repository = $this->em->getRepository(InseeCommune1943::class);
         /** @var InseePays1943Repository $pays1943Repository */

--- a/tests/Functional/BirthPlaceTest.php
+++ b/tests/Functional/BirthPlaceTest.php
@@ -102,6 +102,9 @@ class BirthPlaceTest extends ApiTestCase
     }
 
     /**
+     *
+     * @group now
+     *
      * @throws ClientExceptionInterface
      * @throws RedirectionExceptionInterface
      * @throws ServerExceptionInterface
@@ -145,6 +148,27 @@ class BirthPlaceTest extends ApiTestCase
                 type: 'country'
             )
         );
+
+
+        // Test case 1 : Before 1943, it should use the 1943 rule → "Indes britanniques"
+        $response1 = $this->get('birth_places', [
+            'search' => 'Inde',
+            'dateOfBirth' => (new DateTime('1933-01-01'))->format(DateTimeInterface::ATOM),
+            'limit' => 50,
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+        self::assertNotEmpty($response1['hydra:member']);
+
+        $this->assertResponseContainsBirthPlace(
+            $response1['hydra:member'],
+            new BirthPlaceDTO(
+                label: 'Indes britanniques',
+                code: '99223',
+                type: 'country'
+            )
+        );
+
     }
 
     /**


### PR DESCRIPTION
Attention ! 

Base : bugfix/import-rpps-multiple-address

Si ce n’est pas encore mergé, tu peux cherry-pick le commit, il est très petit.

---

Contexte  
La base "depuis 1943" commence au 1er janvier 1943.  
Lorsqu’une date de naissance antérieure à 1943 est utilisée (par exemple 1936), aucune correspondance n’est trouvée car aucune ligne n’existe avant cette date.

Conséquence  
La méthode `searchBirthPlacesByDate` ne retourne alors aucun résultat et renvoie uniquement "INCONNU".

Résolution  
Un fallback a été ajouté :  
- Pour les dates < 1er janvier 1943, la recherche s’effectue désormais dans la base moderne (`InseePays`), afin de fournir un résultat pertinent.  
- Pour les dates ≥ 1er janvier 1943, la recherche continue de s’appuyer sur la base historique (`InseePays1943`), qui gère correctement les périodes de validité.
